### PR TITLE
Added ability to add mixin to certain files under requirejs bundle

### DIFF
--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -98,9 +98,14 @@ define('mixins', [
          * @param {String} name - Module to be loaded.
          */
         load: function (name, req, onLoad, config) {
-            var path     = getPath(name, config),
-                mixins   = this.getMixins(path),
-                deps     = [name].concat(mixins);
+            var path = getPath(name, config);
+            var mixins = this.getMixins(path);
+
+            if (!mixins || !mixins.length) {
+                mixins = this.getMixins(name);
+            }
+
+            var deps = [name].concat(mixins);
 
             req(deps, function () {
                 onLoad(applyMixins.apply(null, arguments));
@@ -158,7 +163,7 @@ define('mixins', [
             function processName(name) {
                 var path = getPath(name, config);
 
-                if (!hasPlugin(name) && (isRelative(name) || rjsMixins.hasMixins(path))) {
+                if (!hasPlugin(name) && (isRelative(name) || rjsMixins.hasMixins(path) || rjsMixins.hasMixins(name))) {
                     return addPlugin(name);
                 }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
For those who are not using default Magento bundling system it might be useful to use its own bundling. Unfortunately you are not able to add mixin to certain definition inside bundle, only to whole bundle. This is caused by the fact mixins are applied to path, not to name. So this PR suppose to resolve such injustice.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a simple requirejs bundle. Requirejs-config.js, bundles property.
bundles: {
        'Vendor_Module/js/view/bundles/bundle_name': ['definition_name']
    }
2. Add a mixin to some 'definition_name'. It won't be applied

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
